### PR TITLE
kog_patch_31

### DIFF
--- a/Keep On Going/kog_class.py
+++ b/Keep On Going/kog_class.py
@@ -98,24 +98,24 @@ class Music:
             'waves_idea_2.mp3',
             "credits.wav",
         ]
-        self.end = pygame.USEREVENT + 0    # Unique event, for when music ends
+        self.end = pygame.USEREVENT + 0  # Unique event, for when music ends
         pygame.mixer.music.set_endevent(pygame.USEREVENT + 0)
         # Everytime music ends, return the event
 
-        self.file_path = "assets/audio/"    # File path for audio
+        self.file_path = "assets/audio/"  # File path for audio
 
-        self.current_track_index = 0    # Everything but the main menu theme
+        self.current_track_index = 0  # Everything but the main menu theme
 
-        self.perc_vol = perc_vol   # Volume set by the player as a percentage
-        self.music_vol = 0              # Adjustable music volume
-        self.vol_time = pygame.time.get_ticks()     # Increment music with time
-        self.max_vol = 0.7 * self.perc_vol / 100   # Max volume possible for music
+        self.perc_vol = perc_vol  # Volume set by the player as a percentage
+        self.music_vol = 0  # Adjustable music volume
+        self.vol_time = pygame.time.get_ticks()  # Increment music with time
+        self.max_vol = 0.7 * self.perc_vol / 100  # Max volume possible for music
 
         pygame.mixer.music.load(self.file_path + self.music_tracks[0])
         # Load the menu music
 
-        pygame.mixer.music.set_volume(self.max_vol)     # Set to max for now
-        pygame.mixer.music.play(-1)     # Start with main menu, play forever
+        pygame.mixer.music.set_volume(self.max_vol)  # Set to max for now
+        pygame.mixer.music.play(-1)  # Start with main menu, play forever
 
         self.music_text = Text("PLAYING: " +
                                str(self.music_tracks[self.current_track_index]),
@@ -180,8 +180,8 @@ class Music:
         while self.music_vol < self.max_vol and \
                 75 < pygame.time.get_ticks() - self.vol_time:
             self.music_vol += 0.01  # Increase volume
-            pygame.mixer.music.set_volume(self.music_vol)   # Update volume
-            self.vol_time = pygame.time.get_ticks()     # Reset timer
+            pygame.mixer.music.set_volume(self.music_vol)  # Update volume
+            self.vol_time = pygame.time.get_ticks()  # Reset timer
 
 
 class Memory:
@@ -194,12 +194,12 @@ class Memory:
         self.total_deaths = 0  # Total deaths in one session
         self.total_jumps = 0  # Total jumps in one session
         self.total_time = 0  # Total time passed in one session
-        self.total_stars = 0    # Total stars collected
+        self.total_stars = 0  # Total stars collected
 
         self.level_deaths = {}  # Deaths per level in one session
         self.level_jumps = {}  # Jumps per level in one session
         self.level_times = {}  # Times per level in one session
-        self.stars_collected = {}   # Stars collected per level
+        self.stars_collected = {}  # Stars collected per level
 
         self.level_progress = []  # collection of level_id's for levels done
 
@@ -210,7 +210,7 @@ class Memory:
         """Loaded in level data containing text, rects and lines for 
         platforms
         """
-        self.level_id = 0   # Initialize level_id
+        self.level_id = 0  # Initialize level_id
 
         self.id_range = {}  # Ranges for different sets of levels
         self.range_index = 0
@@ -234,11 +234,11 @@ class Memory:
 
         """Variables related to write and read replay class functions
         """
-        self.replay_imp = {}    # Imported replays from an external source
+        self.replay_imp = {}  # Imported replays from an external source
         self.imp_diff = {}  # Imported difficulties
-        self.replay_exp = {}    # Replays from the player ready to export
+        self.replay_exp = {}  # Replays from the player ready to export
 
-        self.hold_replay = ReplayChain()   # Altered Queue for holding jump/unfreeze timings
+        self.hold_replay = ReplayChain()  # Altered Queue for holding jump/unfreeze timings
         # hr_indexes is used to keep indexes for respawns/the latest 5 deaths
 
         # Toggle if replay mode is on or not (only accessed in Replays)
@@ -259,7 +259,7 @@ class Memory:
 
         # Initialize Width and Height of Screen, useful for changing resolutions
         self.res_width = width  # Ratio for width resolution, easily multiply
-        self.res_height = height    # Ratio for height res, easily multiply
+        self.res_height = height  # Ratio for height res, easily multiply
 
         self.res_index = 1
 
@@ -277,10 +277,10 @@ class Memory:
         we denote:
             - 0 for coming from the menu
             - greater than 0 for coming from a level
-            
+
         """
 
-        self.hub_index = 1      # Keep track of current hub accessed
+        self.hub_index = 1  # Keep track of current hub accessed
 
     def update_mem(self, level_id, death_count, jump_count, level_time,
                    stars):
@@ -381,7 +381,7 @@ class Memory:
                 self.load_levels(folder_path + each_file)
 
         # Load non-level pygame objects, start at -6 + 1 for 4 instances
-        self.level_id = -6
+        self.level_id = -99
         # Decrease the level_id for more than 4 instances!
         self.load_levels("assets/levels/non_levels.txt")
 
@@ -477,20 +477,21 @@ class Memory:
                         self.ls_elements[self.level_id][identifier] = [add_text]
                     else:
                         # If there are objects, add onto it
-                        self.ls_elements[self.level_id][identifier] += [add_text]
+                        self.ls_elements[self.level_id][identifier] += [
+                            add_text]
 
         # Extra if statement for the case where there's only 1 thing in the file
         if start is None:
             start = self.level_id
 
-        end = self.level_id     # Get the last level that was added in
+        end = self.level_id  # Get the last level that was added in
         if start + end < 0:
             current_hub = -1
         else:
             current_hub = self.range_index
 
         self.id_range[current_hub] = [start, end]  # Put the range into mem
-        self.range_index += 1   # Increment for the next set of ranges
+        self.range_index += 1  # Increment for the next set of ranges
         # self.print_levels is mainly used for debugging purposes only
         # self.print_levels()
 
@@ -556,11 +557,12 @@ class Memory:
                                      int(math.floor(int(
                                          rect_properties[0]) * self.res_width)),
                                      int(math.floor(int(
-                                         rect_properties[1]) * self.res_height)),
+                                         rect_properties[
+                                             1]) * self.res_height)),
                                      int(math.ceil(int(
                                          rect_properties[2]) * self.res_width)),
                                      int(math.floor(int(rect_properties[
-                                                        3]) * self.res_height))),
+                                                            3]) * self.res_height))),
                                  "rect")
         else:
             """Otherwise the color is defined in words:
@@ -577,15 +579,15 @@ class Memory:
                                  pygame.Rect(
                                      int(math.floor(int(
                                          rect_properties[0]) *
-                                                self.res_width)),
+                                                    self.res_width)),
                                      int(math.floor(int(
                                          rect_properties[1]) *
-                                                self.res_height)),
+                                                    self.res_height)),
                                      int(math.ceil(int(
                                          rect_properties[2]) *
-                                               self.res_width)),
+                                                   self.res_width)),
                                      int(math.floor(int(rect_properties[3]) *
-                                                self.res_height))),
+                                                    self.res_height))),
                                  "rect")
 
         return in_rect
@@ -607,12 +609,12 @@ class Memory:
         in_line = KOGElement(line_info[1], [int(line_info[2][1:]),
                                             int(line_info[3][:-1]),
                                             int(int(line_info[4][1:]) * \
-                                            self.res_width * self.res_height),
+                                                self.res_width * self.res_height),
                                             int(int(line_info[5][:-1]) * \
-                                            self.res_width * self.res_height),
+                                                self.res_width * self.res_height),
                                             int(int(line_info[6][:-1]) * \
-                                            max(self.res_width,
-                                                self.res_height))],
+                                                max(self.res_width,
+                                                    self.res_height))],
                              "line")
         return in_line
 
@@ -678,7 +680,8 @@ class Memory:
                     detect_rect = pygame.Rect((int(get_data[1]) +
                                                (int(get_data[3]) / 2)) -
                                               (int(get_data[5]) / 2),
-                                              (int(get_data[2]) + (int(get_data[4]) / 2)) -
+                                              (int(get_data[2]) + (int(
+                                                  get_data[4]) / 2)) -
                                               (int(get_data[6]) / 2),
                                               int(get_data[5]),
                                               int(get_data[6])
@@ -722,8 +725,10 @@ class Memory:
                     level_counter += 1
                 elif 0 < len(each_line) and each_line != "===\n" and \
                         each_line != "[]\n":
-                    self.replay_imp[level_counter] = each_line[1:-2].split(", ")[2:]
-                    self.imp_diff[level_counter] = int(each_line[1:-1].split(", ")[1])
+                    self.replay_imp[level_counter] = each_line[1:-2].split(
+                        ", ")[2:]
+                    self.imp_diff[level_counter] = int(
+                        each_line[1:-1].split(", ")[1])
 
     def init_replays(self):
         level_counter = 1
@@ -737,7 +742,7 @@ class Memory:
         self.replay_exp[level_id] = replay_info
 
     def update_temp(self, replay_info):
-        self.hold_replay.append(replay_info)    # replay_info must be a list
+        self.hold_replay.append(replay_info)  # replay_info must be a list
 
     def replays_on(self):
         self.enable_replay = True
@@ -759,7 +764,6 @@ class Memory:
             open_file.write(str(self.level_progress) + "\n")
             open_file.write(str(self.stars_collected) + "\n")
 
-
             open_file.write(str(self.diff_value) + "\n")
             open_file.write(str(self.bg_slider) + "\n")
             open_file.write(str(self.quick_restart) + "\n")
@@ -769,12 +773,14 @@ class Memory:
     # load_save will load miscellaneous data from file
 
     def load_save(self):
+        # todo: change this value to the desired file length
+        check_len = 14
         file_path = "assets/saves/save_file1.txt"
         if os.path.isfile(file_path):
             with open(file_path, "r") as test_file:
                 file_len = len(test_file.readlines())
 
-        if os.path.isfile(file_path) and file_len == 12:
+        if os.path.isfile(file_path) and file_len == check_len:
             get_save = open(file_path, "r")
             self.total_deaths = int(get_save.readline())
             self.total_jumps = int(get_save.readline())
@@ -825,7 +831,7 @@ class Memory:
             self.total_music_per = int(get_save.readline())
             pygame.mixer.music.set_volume(self.total_music_per)
             self.sound_vol = float(get_save.readline())
-        elif os.path.isfile(file_path) and file_len != 12:
+        elif os.path.isfile(file_path) and file_len == check_len:
             get_save = open(file_path, "w")
         else:
             # No previous save made
@@ -838,13 +844,15 @@ class Memory:
 
 class ReplayBlock:
     """A more convenient way to hold replay info, the info in each node"""
+
     def __init__(self, times, in_type):
-        self.times = times        # Time for that action
-        self.type = in_type     # Type of action
+        self.times = times  # Time for that action
+        self.type = in_type  # Type of action
 
 
 class ReplayNode:
     """Acts as a node for the chain, only to be used with ReplayChain"""
+
     def __init__(self, item):
         self.item = item
         self.next = None
@@ -907,10 +915,11 @@ class ReplayChain:
 
 class KOGElement:
     """A more convenient way to hold level element info"""
+
     def __init__(self, color, shape, in_type):
         self.color = color  # Block color
         self.shape = shape  # Block shape
-        self.type = in_type     # Distinguish line vs rect types
+        self.type = in_type  # Distinguish line vs rect types
 
 
 class Animate:
@@ -949,7 +958,7 @@ class Animate:
                 self.img_rect.y < 0 or 576 < self.img_rect.y:
             return "Invalid y position out of bounds or not given"
         elif self.frame_delay is None or type(self.frame_delay) is not int or \
-            type(self.frame_delay) is not float:
+                type(self.frame_delay) is not float:
             return "Frame delay is invalid (not int or float)"
 
     def animate(self, screen):
@@ -985,7 +994,7 @@ class Collectable:
 
     def __init__(self, object_id, collect_rect, detect_rect, roam_rect):
         self.alive = True
-        self.freeze = False     # Determine if star should move
+        self.freeze = False  # Determine if star should move
 
         self.id = object_id
         self.rect = collect_rect
@@ -993,15 +1002,15 @@ class Collectable:
         self.roam_rect = roam_rect
         self.fldr_id = [
             "stars/"
-        ]   # object id to which folder they should use
+        ]  # object id to which folder they should use
         """
         an id of 0 is unspecific and uses all files in the stars folder
         """
 
         self.animate_star = Animate("assets/images/" +
                                     self.fldr_id[object_id],
-                               self.rect.x, self.rect.y,
-                               self.rect.width, self.rect.height, 2)
+                                    self.rect.x, self.rect.y,
+                                    self.rect.width, self.rect.height, 2)
 
         if not self.animate_star.validate():
             raise "UNABLE TO LOAD STAR DATA"
@@ -1022,9 +1031,9 @@ class Collectable:
 
     def render_test(self, screen):
         # Render unrendered rects for debugging
-        pygame.draw.rect(screen, RED, self.roam_rect)       # Roam rect
-        pygame.draw.rect(screen, BLUE, self.detect_rect)    # Detection rect
-        pygame.draw.rect(screen, YELLOW, self.rect)         # Image rect
+        pygame.draw.rect(screen, RED, self.roam_rect)  # Roam rect
+        pygame.draw.rect(screen, BLUE, self.detect_rect)  # Detection rect
+        pygame.draw.rect(screen, YELLOW, self.rect)  # Image rect
 
     def update(self, player_rect):
         """Move delay used in self.detect_bounds(): if enough time
@@ -1071,17 +1080,17 @@ class Collectable:
 
         # If the player is to the left of the star
         if player_rect.x < self.rect.x:
-            self.move_x = 1     # move right
+            self.move_x = 1  # move right
         # If the player is to the right of the star
         elif self.rect.x + self.rect.width < player_rect.x:
-            self.move_x = -1    # move left
+            self.move_x = -1  # move left
 
         # If the player is above the star
         if player_rect.y < self.rect.y:
-            self.move_y = 1     # move down
+            self.move_y = 1  # move down
         # If the player is below the star
         elif self.rect.y + self.rect.height < player_rect.y:
-            self.move_y = -1    # move up
+            self.move_y = -1  # move up
 
         # Detect if player is touching, if so, get removed
         if player_rect.colliderect(self.rect):
@@ -1091,22 +1100,22 @@ class Collectable:
         # If the star is out to the right of the barrier
         if self.roam_rect.x + self.roam_rect.width <= \
                 self.rect.x + self.rect.width:
-            self.move_x = -1    # move back to the left
-            self.move_delay = pygame.time.get_ticks()   # move for x seconds
+            self.move_x = -1  # move back to the left
+            self.move_delay = pygame.time.get_ticks()  # move for x seconds
         # If the star is out to the left of the barrier
         elif self.rect.x <= self.roam_rect.x:
-            self.move_x = 1     # move back to the right
-            self.move_delay = pygame.time.get_ticks()   # move for x seconds
+            self.move_x = 1  # move back to the right
+            self.move_delay = pygame.time.get_ticks()  # move for x seconds
 
         # If the star is below the barrier
         if self.roam_rect.y + self.roam_rect.height <= \
                 self.rect.y + self.rect.height:
-            self.move_y = -1    # move back up into the barrier
-            self.move_delay = pygame.time.get_ticks()   # move for x seconds
+            self.move_y = -1  # move back up into the barrier
+            self.move_delay = pygame.time.get_ticks()  # move for x seconds
         # If the star is above the barrier
         elif self.rect.y <= self.roam_rect.y:
-            self.move_y = 1     # move back down into the barrier
-            self.move_delay = pygame.time.get_ticks()   # move for x seconds
+            self.move_y = 1  # move back down into the barrier
+            self.move_delay = pygame.time.get_ticks()  # move for x seconds
 
     def random_movement(self):
         # randomly set the direction of x and y from -1, 0, then 1
@@ -1131,7 +1140,7 @@ class SquareMe:  # lil purple dude
         ]
         """
         self.xpos = x_spawn  # Current x_position, initialized as spawn
-        self.ypos = y_spawn # Current y_position, initialized as spawn
+        self.ypos = y_spawn  # Current y_position, initialized as spawn
         self.width = math.ceil(width * res_width)  # Current width, always 10
         self.height = math.ceil(height * res_height)
         # Current height, always 10
@@ -1167,10 +1176,14 @@ class SquareMe:  # lil purple dude
                                     self.ypos + (res_height * 1),
                                     self.width + (res_width * 10),
                                     8 * res_height)
-        self.right_col = pygame.Rect(self.xpos + self.width, self.ypos + (res_height * 1),
-                                    self.width + (10 * res_width), 8 * res_height)
-        self.top_col = pygame.Rect(self.xpos, self.ypos - self.height - (10 * res_height),
-                                    10 * res_width, self.height + (10 * res_height))
+        self.right_col = pygame.Rect(self.xpos + self.width,
+                                     self.ypos + (res_height * 1),
+                                     self.width + (10 * res_width),
+                                     8 * res_height)
+        self.top_col = pygame.Rect(self.xpos,
+                                   self.ypos - self.height - (10 * res_height),
+                                   10 * res_width,
+                                   self.height + (10 * res_height))
         self.bot_col = pygame.Rect(self.xpos, self.ypos + self.height,
                                    10 * res_width, self.height * 4)
 
@@ -1534,6 +1547,7 @@ class KOGLog:
 
     def __init__(self):
         pass
+
 
 """
 !! NOTICE !!

--- a/Keep On Going/kog_levels.py
+++ b/Keep On Going/kog_levels.py
@@ -22,10 +22,11 @@ DARK_GREY = (52, 52, 52)
 DARK_PURPLE = (80, 35, 105)
 GOLDELLOW = (245, 180, 65)
 
-# global variable 
+# global variable
 LVL_ID = -99
 MENU_ID = -98
 OPTIONS_ID = -97
+
 
 class LevelScene(kogclass.Scene):
     """
@@ -139,7 +140,6 @@ class LevelScene(kogclass.Scene):
         self.render_objects = []
         self.collision_objects = {}
 
-
         self.pause_options = {
             0: self.restart_death, 1: self.access_options,
             2: self.return_to_menu, 3: self.stop_level
@@ -160,11 +160,11 @@ class LevelScene(kogclass.Scene):
 
         # Useful to render an outline over these options
         # Should have the same length as pause_options
-        
+
         self.pause_list = [
-            self.pause_text_3, 
+            self.pause_text_3,
             self.pause_text_4,
-            self.pause_text_5, 
+            self.pause_text_5,
             self.pause_text_6,
         ]
 
@@ -447,9 +447,6 @@ class MenuScene(LevelScene):
         # Main menu options
 
         # Main menu text
-        self.title_splash = kogclass.Text("DON'T STOP NOW", (540, 100), 100,
-                                          "impact", YELLOW, None)
-        self.title_splash.scale(self.memory.res_width, self.memory.res_height)
         self.title_text = kogclass.Text("Press Space or W To Start", (530, 200),
                                         50, "impact",
                                         YELLOW, None)
@@ -458,10 +455,19 @@ class MenuScene(LevelScene):
                                           "impact",
                                           YELLOW, None)
         self.title_text_2.scale(self.memory.res_width, self.memory.res_height)
-        self.title_text_s1 = kogclass.Text("Level Select", (216, 445), 30,
+
+        # Two types of text depending on game progress (new vs. continuing)
+        self.title_text_s1_new = kogclass.Text("New Game", (216, 445), 30,
                                            "impact",
                                            YELLOW, None)
-        self.title_text_s1.scale(self.memory.res_width, self.memory.res_height)
+        self.title_text_s1_new.scale(self.memory.res_width,
+                                 self.memory.res_height)
+        self.title_text_s1_cont = kogclass.Text("Continue", (216, 445), 30,
+                                           "impact",
+                                           YELLOW, None)
+        self.title_text_s1_cont.scale(self.memory.res_width,
+                                      self.memory.res_height)
+
         self.title_text_s2 = kogclass.Text("Options", (432, 445), 30,
                                            "impact",
                                            YELLOW, None)
@@ -522,44 +528,21 @@ class MenuScene(LevelScene):
                                     self.going_image_text.get_rect().height *
                                     self.memory.res_height * 0.225))
 
-        # Text for displaying title select options organized in a lists
-        self.option_select = [
-            [self.title_text_s1.text_rect.x - 5,
-             self.title_text_s1.text_rect.y - 5,
-             self.title_text_s1.text_rect.width + 10,
-             self.title_text_s1.text_rect.height + 10],
-            [self.title_text_s2.text_rect.x - 5,
-             self.title_text_s2.text_rect.y - 5,
-             self.title_text_s2.text_rect.width + 10,
-             self.title_text_s2.text_rect.height + 10],
-            [self.title_text_s3.text_rect.x - 5,
-             self.title_text_s3.text_rect.y - 5,
-             self.title_text_s3.text_rect.width + 10,
-             self.title_text_s3.text_rect.height + 10],
-            [self.title_text_s4.text_rect.x - 5,
-             self.title_text_s4.text_rect.y - 5,
-             self.title_text_s4.text_rect.width + 10,
-             self.title_text_s4.text_rect.height + 10],
-            [self.title_text_s5.text_rect.x - 5,
-             self.title_text_s5.text_rect.y - 5,
-             self.title_text_s5.text_rect.width + 10,
-             self.title_text_s5.text_rect.height + 10],
-            [self.title_text_s6.text_rect.x - 5,
-             self.title_text_s6.text_rect.y - 5,
-             self.title_text_s6.text_rect.width + 10,
-             self.title_text_s6.text_rect.height + 10],
-            [self.title_text_s7.text_rect.x - 5,
-             self.title_text_s7.text_rect.y - 5,
-             self.title_text_s7.text_rect.width + 10,
-             self.title_text_s7.text_rect.height + 10],
-            [self.title_text_s8.text_rect.x - 5,
-             self.title_text_s8.text_rect.y - 5,
-             self.title_text_s8.text_rect.width + 10,
-             self.title_text_s8.text_rect.height + 10]
-        ]
+        # Highlight specific rect
+        if len(self.memory.level_progress) < 2:
+            add_rect = self.title_text_s1_new.text_rect
+        else:
+            add_rect = self.title_text_s1_cont.text_rect
 
-        """self.title_guy = kogclass.SquareMe(xspawn, yspawn,
-                                        10, 10, (181, 60, 177))"""
+        self.option_select = [add_rect,
+                              self.title_text_s2.text_rect,
+                              self.title_text_s3.text_rect,
+                              self.title_text_s4.text_rect,
+                              self.title_text_s5.text_rect,
+                              self.title_text_s6.text_rect,
+                              self.title_text_s7.text_rect,
+                              self.title_text_s8.text_rect
+        ]
 
         self.load_renders(MENU_ID)
 
@@ -569,13 +552,15 @@ class MenuScene(LevelScene):
         for every_key in pressed:
             # If player chooses option, update menu statistics and change scene
             if every_key in [pygame.K_SPACE]:
-                self.memory.music.switch_music() # might need to change this
+                self.memory.music.switch_music()  # might need to change this
                 self.memory.update_mem(self.level_id, self.deaths,
                                        self.player.jumps, self.start_time, 0)
                 if self.option_count == 1:
                     self.memory.options_status = 0
                 elif self.option_count == 5:
-                    self.memory.music.set_music(self.memory.hub_index, self.memory.music.max_vol, -1, 0, 0)
+                    self.memory.music.set_music(self.memory.hub_index,
+                                                self.memory.music.max_vol, -1,
+                                                0, 0)
                 self.change_scene(self.options[self.option_count])
             # Press right/d to move right of the selection
             if every_key is pygame.K_d:
@@ -635,9 +620,14 @@ class MenuScene(LevelScene):
             410 * self.memory.res_width - 5, 10 * self.memory.res_height))
         screen.blit(self.going_image_text, (
             720 * self.memory.res_width - 95, 10 * self.memory.res_height))
-        """screen.blit(self.title_text.text_img, self.title_text.text_rect)
-        screen.blit(self.title_text_2.text_img, self.title_text_2.text_rect)"""
-        screen.blit(self.title_text_s1.text_img, self.title_text_s1.text_rect)
+
+        if len(self.memory.level_progress) < 2:
+            screen.blit(self.title_text_s1_new.text_img,
+                        self.title_text_s1_new.text_rect)
+        else:
+            screen.blit(self.title_text_s1_cont.text_img,
+                        self.title_text_s1_cont.text_rect)
+
         screen.blit(self.title_text_s2.text_img, self.title_text_s2.text_rect)
         screen.blit(self.title_text_s3.text_img, self.title_text_s3.text_rect)
         screen.blit(self.title_text_s4.text_img, self.title_text_s4.text_rect)
@@ -655,7 +645,10 @@ class MenuScene(LevelScene):
 
         # Menu selector box highlight
         pygame.draw.rect(screen, DARK_RED,
-                         self.option_select[self.option_count], 2)
+                         [self.option_select[self.option_count].x - 5,
+                          self.option_select[self.option_count].y - 5,
+                          self.option_select[self.option_count].width + 10,
+                          self.option_select[self.option_count].height + 10], 2)
 
 
 class HubzonePlayer(kogclass.SquareMe):
@@ -665,6 +658,7 @@ class HubzonePlayer(kogclass.SquareMe):
                                    diff,
                                    res_width, res_height, jump_vol)
         self.max_jump = 100
+
     def move(self):
 
         move_factor = (4 * self.direction) * self.diff_factor * self.res_width
@@ -703,8 +697,8 @@ class Hubzones(LevelScene):
             # hubzone 2 background
         }
         self.pause_options = {
-            0: self.restart_death, 1: self.return_to_menu,
-            2: self.stop_level, 3: self.go_to_options
+            0: self.restart_death, 1: self.go_to_options,
+            2: self.return_to_menu, 3: self.stop_level
         }
         self.level_elements = level_memory.ls_elements
         self.backgrounds = {
@@ -721,9 +715,11 @@ class Hubzones(LevelScene):
 
         self.backgrounds[self.memory.hub_index] = \
             pygame.transform.scale(self.backgrounds[self.memory.hub_index],
-                                   (self.backgrounds[self.memory.hub_index].get_rect().width *
+                                   (self.backgrounds[
+                                        self.memory.hub_index].get_rect().width *
                                     self.memory.res_width,
-                                    self.backgrounds[self.memory.hub_index].get_rect().height *
+                                    self.backgrounds[
+                                        self.memory.hub_index].get_rect().height *
                                     self.memory.res_height))
         self.text_bubbles = [
             kogclass.Text("Text Bubbble", (310, 100), 25, "impact", GREY, None),
@@ -736,12 +732,13 @@ class Hubzones(LevelScene):
         self.text_bubbles[1].scale(level_memory.res_width,
                                    level_memory.res_height)
         self.options_page = False
-        self.load_renders(-96) # needs to be changed as well
+        self.load_renders(-96)  # needs to be changed as well
 
         self.special_objects = [pygame.Rect(200, 500, 30, 30),
                                 pygame.Rect(800, 500, 30, 30),
-                                pygame.Rect(800, 300, 180, 80)] # this for the sign
-        
+                                pygame.Rect(800, 300, 180,
+                                            80)]  # this for the sign
+
         self.special_options = [self.return_to_menu, self.go_to_options,
                                 self.go_to_hubselect]
 
@@ -799,15 +796,27 @@ class Hubzones(LevelScene):
                     self.death_zones = []
                     self.respawn_zones = []
                     self.memory.options_status = self.level_id
-                    self.load_renders(OPTIONS_ID) # options page during the game
+                    self.load_renders(
+                        OPTIONS_ID)  # options page during the game
             if every_key in [pygame.K_s]:
-                if -1 < self.player.square_render.collidelist(self.special_objects):
+                if -1 < self.player.square_render.collidelist(
+                        self.special_objects):
                     self.special_options[
-                        self.player.square_render.collidelist(self.special_objects)]()
+                        self.player.square_render.collidelist(
+                            self.special_objects)]()
 
-        if held[pygame.K_a]:
+            if every_key == pygame.K_d and \
+                    1080 - self.player.width < self.player.xpos:
+                self.change_scene(LevelSelect(self.memory))
+            elif every_key == pygame.K_a and \
+                    self.player.xpos < 0:
+                self.change_scene(LevelSelect(self.memory))
+
+        if held[pygame.K_a] and \
+                0 <= self.player.xpos:
             self.player.direction = -1
-        elif held[pygame.K_d]:
+        elif held[pygame.K_d] and \
+                self.player.xpos + self.player.width <= 1080:
             self.player.direction = 1
         else:
             self.player.direction = 0
@@ -1024,8 +1033,6 @@ class OptionsPage(LevelScene):
                     self.respawn_zones = []
                     self.access_options()
                     self.load_renders(self.memory.options_status)
-            
-
 
         if held[pygame.K_a] and (1000 / self.change_speed) < \
                 pygame.time.get_ticks() - self.change_time and \
@@ -1593,11 +1600,6 @@ class UniversalSelect(LevelScene):
         """Initialize LevelScene with player parameters to the middle
         of the screen.
         """
-        self.filler_text = kogclass.Text("Choose A Level",
-                                         (540, 153), 50, "impact", YELLOW, None)
-        self.filler_text.scale(self.memory.res_width,
-                               self.memory.res_height)
-
         self.level_selector_text_0 = kogclass.Text("Choose a Level", (535, 100),
                                                    65,
                                                    "impact", YELLOW, None)
@@ -1631,7 +1633,7 @@ class UniversalSelect(LevelScene):
         self.blockmation_time = 0  # Time variable for moving level boxes
         self.text_x = 0  # Used to define the x position of level number text
         self.direction = 0  # Toggle determining direction level text moves
-        self.choose_id = 0      # Rewrite in child class, int greater than 0
+        self.choose_id = 0  # Rewrite in child class, int greater than 0
 
         self.memory = level_memory
 
@@ -1639,18 +1641,18 @@ class UniversalSelect(LevelScene):
         self.speed_jump = 1  # Determines selection speed
         self.allow_select = True  # If levels can be freely chosen
 
-        self.level_set = []   # Rewrite in child class, should be list
+        self.level_set = []  # Rewrite in child class, should be list
         self.confirm_timer = pygame.time.get_ticks() - 3000
 
-        self.level_offset = 0   # Visually offset numbers
+        self.level_offset = 0  # Visually offset numbers
 
     def input(self, pressed, held):
         for every_key in pressed:
             # Return player to menu if pressing "R"
             if every_key == pygame.K_r:
-                self.memory.music.set_music(0, self.memory.music.max_vol, -1, 0,
-                                            0)
-                self.change_scene(MenuScene(24, 303, self.memory))
+                self.memory.music.set_music(self.memory.hub_index,
+                                            self.memory.music.max_vol, -1, 0, 0)
+                self.change_scene(Hubzones(0, 0, self.memory))
 
             # Allow player to choose a level (based on ID) after 0.405 seconds
             if self.allow_select and \
@@ -1861,7 +1863,7 @@ class LevelSelect(UniversalSelect):
     def __init__(self, level_memory):
         UniversalSelect.__init__(self, level_memory)
         self.level_set = self.memory.id_range[self.memory.hub_index]
-        self.choose_id = self.level_set[0]      # Level ID chosen
+        self.choose_id = self.level_set[0]  # Level ID chosen
         self.level_offset = self.choose_id - 1
 
     def input(self, pressed, held):
@@ -1887,6 +1889,12 @@ class HubSelect(LevelSelect):
         UniversalSelect.__init__(self, level_memory)
         self.level_set = [1, len(self.memory.id_range) - 1]
         self.choose_id = self.memory.hub_index + 1
+        self.level_selector_text_0 = kogclass.Text("Choose a Hubzone",
+                                                   (535, 100),
+                                                   65,
+                                                   "impact", YELLOW, None)
+        self.level_selector_text_0.scale(self.memory.res_width,
+                                         self.memory.res_height)
 
     def input(self, pressed, held):
         UniversalSelect.input(self, pressed, held)
@@ -1895,7 +1903,8 @@ class HubSelect(LevelSelect):
                     every_key in [pygame.K_UP, pygame.K_SPACE, pygame.K_w] and \
                     405 < pygame.time.get_ticks() - self.blockmation_time:
                 self.memory.hub_index = self.choose_id - 1
-                self.memory.music.set_music(self.memory.hub_index, self.memory.music.max_vol, -1, 0, 0)
+                self.memory.music.set_music(self.memory.hub_index,
+                                            self.memory.music.max_vol, -1, 0, 0)
                 self.change_scene(Hubzones(0, 0, self.memory))
                 # Load a level using memory and that level id
 
@@ -2198,12 +2207,20 @@ class PlayLevel(LevelSelect, OptionsPage):
                 self.level_id += 1
 
                 if self.level_id in self.level_data:
-                    self.change_scene(
-                        PlayLevel(self.level_data[self.level_id][0],
-                                  self.level_data[self.level_id][1],
-                                  self.memory,
-                                  self.level_id))
+                    if self.memory.id_range[self.memory.hub_index][0] \
+                            <= self.level_id <= \
+                            self.memory.id_range[self.memory.hub_index][1]:
+                        self.change_scene(
+                            PlayLevel(self.level_data[self.level_id][0],
+                                      self.level_data[self.level_id][1],
+                                      self.memory,
+                                      self.level_id))
+                    else:
+                        self.memory.hub_index += 1
+                        self.change_scene(Hubzones(0, 0, self.memory))
                 else:
+                    # The very last level
+                    # todo: Change this in the future for endings etc
                     self.change_scene(MenuScene(24, 303, self.memory))
         # Replay Mode
         else:


### PR DESCRIPTION
November 25th Bug Fixes
- Fixed kog_class to have a correct level_id when loading in levels (it wasn't updated last level)
- Fixed kog_levels' Hubzones to have the correct pause options (we forgot last update)
- Fixed the player walking offscreen if there's no boundaries
- Fixed the text associated with Hubzones because it was displaying "Choose a level" before
- Changed value checking for a specific file length in saves, causing saves to not be read in

New Features
- Added the ability to choose levels from HubZones when you press A/D near the edges. This resolves #390 
- The game now checks for a new or continuing playthrough (you'll see on MenuScreen). If required, we can make a memory variable to see if it's the players first time running it or not. This will resolve #387 
- Both of these features means "LevelSelect", "Hubzones" and "HubSelect" options have been replaced by a "Continue" or "New Game" button in MenuScene