### PR TITLE
kog patch 35

### DIFF
--- a/Keep On Going/kog_class.py
+++ b/Keep On Going/kog_class.py
@@ -86,23 +86,22 @@ class Music:
     """
 
     def __init__(self, perc_vol):
-        self.music_tracks = [
-            "main_menu.wav",
-            "level_loop1.wav",
-            "work_around_lead_edited.wav",
-            "good_vibes_4.mp3",
-            "maybe_sad_broken_ideas.mp3",
-            "song_1.mp3",
-            "tension_idea_4.mp3",
-            'tension_idea_5.mp3',
-            'waves_idea_2.mp3',
-            "credits.wav",
-        ]
+        self.music_tracks = []
+        self.file_path = "assets/audio/soundtracks/"    # File path for audio
+        try:
+            for music in os.listdir(self.file_path):
+                if "mp3" in music or "wav" in music:
+                    self.music_tracks += [str(music)]
+        except:
+            # todo: ERROR LOG
+            raise "Problem with Loading Music"
+
+        self.hub_tracks = {}    # Hub number: [n,m] - song range for that hub
+        self.level_tracks = {}  # Level number: [o,p] - song range for levels
+
         self.end = pygame.USEREVENT + 0  # Unique event, for when music ends
         pygame.mixer.music.set_endevent(pygame.USEREVENT + 0)
         # Everytime music ends, return the event
-
-        self.file_path = "assets/audio/"  # File path for audio
 
         self.current_track_index = 0  # Everything but the main menu theme
 
@@ -146,6 +145,20 @@ class Music:
         pygame.mixer.music.set_volume(self.music_vol)
 
         pygame.mixer.music.play(0, 0, 0)  # Play the music once
+
+    def next_track(self):
+        if len(self.music_tracks) - 1 < self.current_track_index + 1:
+            self.current_track_index = 0
+        else:
+            self.current_track_index += 1
+        self.set_music(self.current_track_index, self.max_vol, -1, 0, 0)
+
+    def previous_track(self):
+        if self.current_track_index - 1 < 0:
+            self.current_track_index = len(self.music_tracks) - 1
+        else:
+            self.current_track_index -= 1
+        self.set_music(self.current_track_index, self.max_vol, -1, 0, 0)
 
     def set_music(self, track_num, vol, loops, start, fade_in):
         # Set the max volume

--- a/Keep On Going/kog_levels.py
+++ b/Keep On Going/kog_levels.py
@@ -233,6 +233,12 @@ class LevelScene(kogclass.Scene):
                         self.memory.options_status = self.level_id
                         self.load_renders(OPTIONS_ID)
 
+                # Change music tracks
+                if every_key == pygame.K_n:
+                    self.memory.music.next_track()
+                elif every_key == pygame.K_b:
+                    self.memory.music.previous_track()
+
         # Held controls for jumping
         if (held[pygame.K_SPACE] or held[pygame.K_w] or held[pygame.K_UP]) \
                 and not self.player.enable_gravity and self.player.alive and \


### PR DESCRIPTION
- Added ability to move onto next/previous tracks in Music Class
- Music is now imported with a check for mp3/wav files only and will not need to be changed for new tracks added (unless it's a different file format)
- Added variables for the future specifying song ranges for hubs/levels
- You can now switch songs with N (next track) and B (previous track) in levels

**WARNING**: Letting you know that these resolves #413 and resolves #416 only to an extent. Currently, there are no specific songs specified for each level set or hub, which limits how this will be implemented now vs. later. Therefore, when we start to make more music with specific themes for these levels/hubs, it'll be easier to add it then (only a few lines in both kog_levels/kog_class) rather than make workarounds now and remove them later.